### PR TITLE
Update Cold Sweat Compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -116,7 +116,7 @@ include_architectury=true
 architectury_version=9.1.12
 
 include_cold_sweat=true
-coldsweat_fileid=4959624
+coldsweat_fileid=6503192
 
 include_guard_villagers=true
 guardvillagers_fileid=4800776

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 # forge
 minecraft_version=1.20.1
 minecraft_version_range=[1.20.1,1.21)
-forge_version=47.1.0
+forge_version=47.4.0
 forge_version_range=[47,)
 loader_version_range=[47,)
 mcp_mappings=1.20.1

--- a/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatCompat.java
+++ b/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatCompat.java
@@ -28,7 +28,7 @@ public class ColdSweatCompat implements IModCompat {
     @Nullable
     @Override
     public String getAcceptedVersionRange() {
-        return "[2.2.3,)";
+        return "[2.3.13,)";
     }
 
     @Override

--- a/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatCompat.java
+++ b/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatCompat.java
@@ -16,7 +16,7 @@ public class ColdSweatCompat implements IModCompat {
     @Override
     public void buildConfig(ForgeConfigSpec.Builder builder) {
         enableTemperatureVampires = builder.comment("Grant vampires cold resistance, but decrease heat resistance").define("enableTemperatureVampires", true);
-        vampireColdResistance = builder.comment("Increase cold resistance for vampires by this degree celsius").defineInRange("vampireColdResistance", 20d, 0, 100);
+        vampireColdResistance = builder.comment("Increase cold resistance for vampires by this degree celsius").defineInRange("vampireColdResistance", 30d, 0, 100);
         vampireBurningPointModifier = builder.comment("Decrease the burning point of vampires by this factor").defineInRange("vampireBurningPointModifier", 0.7, 0, 1);
     }
 

--- a/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatEventHandler.java
@@ -35,6 +35,7 @@ public class ColdSweatEventHandler {
                 if (coldRes != null) {
                     if (vamp) {
                         if (coldRes.getModifier(VAMPIRE_MOD_UUID) == null) {
+                            //Reduce the freezing point for vampires by the configured value in Celsius
                             coldRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", Temperature.convert(-ColdSweatCompat.vampireColdResistance.get(), Temperature.Units.C, Temperature.Units.MC, true), AttributeModifier.Operation.ADDITION));
                         }
                     } else {
@@ -45,6 +46,7 @@ public class ColdSweatEventHandler {
                 if (heatRes != null) {
                     if (vamp) {
                         if (heatRes.getModifier(VAMPIRE_MOD_UUID) == null) {
+                            //Scale the burning point by a configured factor. Must subtract one due to attribute modifier logic
                             heatRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", - 1 + ColdSweatCompat.vampireBurningPointModifier.get(), AttributeModifier.Operation.MULTIPLY_TOTAL));
                         }
                     } else {

--- a/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatEventHandler.java
@@ -35,7 +35,7 @@ public class ColdSweatEventHandler {
                 if (coldRes != null) {
                     if (vamp) {
                         if (coldRes.getModifier(VAMPIRE_MOD_UUID) == null) {
-                            coldRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", Temperature.convertUnits(ColdSweatCompat.vampireColdResistance.get(), Temperature.Units.C, Temperature.Units.MC, true), AttributeModifier.Operation.ADDITION));
+                            coldRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", Temperature.convert(-ColdSweatCompat.vampireColdResistance.get(), Temperature.Units.C, Temperature.Units.MC, true), AttributeModifier.Operation.ADDITION));
                         }
                     } else {
                         coldRes.removeModifier(VAMPIRE_MOD_UUID);


### PR DESCRIPTION
Cold Sweat broke for this version, so I took a shot at fixing it. Also made vampireColdResistance negative because it being positive made vampire players experience immediate cold and jump straight up to immediate heat with almost zero in-between.

Forge version was updated to 47.4.0 to stop Cold Sweat breaking during the loading process. For whatever reason, their mixins don't work on 47.1.0.