### PR TITLE
[1.20.X] Improve Cold Sweat compatibility

### DIFF
--- a/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatEventHandler.java
+++ b/src/main/java/de/teamlapen/vampirism_integrations/coldsweat/ColdSweatEventHandler.java
@@ -3,11 +3,14 @@ package de.teamlapen.vampirism_integrations.coldsweat;
 import com.momosoftworks.coldsweat.api.util.Temperature;
 import de.teamlapen.vampirism.api.VReference;
 import de.teamlapen.vampirism.api.event.PlayerFactionEvent;
+import de.teamlapen.vampirism.util.Helper;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.registries.RegistryObject;
 import org.apache.logging.log4j.LogManager;
@@ -31,35 +34,63 @@ public class ColdSweatEventHandler {
         if (ColdSweatCompat.enableTemperatureVampires.get()) {
             try {
                 boolean vamp = event.getCurrentFaction() == VReference.VAMPIRE_FACTION;
-                AttributeInstance coldRes = event.getPlayer().getPlayer().getAttribute(FREEZING_POINT.get());
-                if (coldRes != null) {
-                    if (vamp) {
-                        if (coldRes.getModifier(VAMPIRE_MOD_UUID) == null) {
-                            //Reduce the freezing point for vampires by the configured value in Celsius
-                            coldRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", Temperature.convert(-ColdSweatCompat.vampireColdResistance.get(), Temperature.Units.C, Temperature.Units.MC, true), AttributeModifier.Operation.ADDITION));
-                        }
-                    } else {
-                        coldRes.removeModifier(VAMPIRE_MOD_UUID);
-                    }
-                }
-                AttributeInstance heatRes = event.getPlayer().getPlayer().getAttribute(BURNING_POINT.get());
-                if (heatRes != null) {
-                    if (vamp) {
-                        if (heatRes.getModifier(VAMPIRE_MOD_UUID) == null) {
-                            //Scale the burning point by a configured factor. Must subtract one due to attribute modifier logic
-                            heatRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", - 1 + ColdSweatCompat.vampireBurningPointModifier.get(), AttributeModifier.Operation.MULTIPLY_TOTAL));
-                        }
-                    } else {
-                        heatRes.removeModifier(VAMPIRE_MOD_UUID);
-                    }
-                }
-
+                ModifyTemperatureValues(event.getPlayer().getPlayer(), vamp);
 
             } catch (Throwable e) {
                 if (warnTemperature) {
-                    LOGGER.error("Failed to modify temperature resistance for vampires", e);
+                    LOGGER.error("Failed to modify temperature resistance for vampires (faction event)", e);
                     warnTemperature = false;
                 }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        VanillaEventHandler(event);
+    }
+
+    @SubscribeEvent
+    public void onLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        VanillaEventHandler(event);
+    }
+
+    private void VanillaEventHandler(PlayerEvent event) {
+        if (ColdSweatCompat.enableTemperatureVampires.get()) {
+            try {
+                boolean vamp = Helper.isVampire(event.getEntity());
+                ModifyTemperatureValues(event.getEntity(), vamp);
+
+            } catch (Throwable e) {
+                if (warnTemperature) {
+                    LOGGER.error("Failed to modify temperature resistance for vampires (vanilla event)", e);
+                    warnTemperature = false;
+                }
+            }
+        }
+    }
+
+    private void ModifyTemperatureValues(Player player, boolean vamp) {
+        AttributeInstance coldRes = player.getAttribute(FREEZING_POINT.get());
+        if (coldRes != null) {
+            if (vamp) {
+                if (coldRes.getModifier(VAMPIRE_MOD_UUID) == null) {
+                    //Reduce the freezing point for vampires by the configured value in Celsius
+                    coldRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", Temperature.convert(-ColdSweatCompat.vampireColdResistance.get(), Temperature.Units.C, Temperature.Units.MC, true), AttributeModifier.Operation.ADDITION));
+                }
+            } else {
+                coldRes.removeModifier(VAMPIRE_MOD_UUID);
+            }
+        }
+        AttributeInstance heatRes = player.getAttribute(BURNING_POINT.get());
+        if (heatRes != null) {
+            if (vamp) {
+                if (heatRes.getModifier(VAMPIRE_MOD_UUID) == null) {
+                    //Scale the burning point by a configured factor. Must subtract one due to attribute modifier logic
+                    heatRes.addTransientModifier(new AttributeModifier(VAMPIRE_MOD_UUID, "vampire", - 1 + ColdSweatCompat.vampireBurningPointModifier.get(), AttributeModifier.Operation.MULTIPLY_TOTAL));
+                }
+            } else {
+                heatRes.removeModifier(VAMPIRE_MOD_UUID);
             }
         }
     }


### PR DESCRIPTION
As of #123, dying or rejoining the world would cause the player to lose the temperature modifications they had previously. This was an oversight on my end and this pull request remedies the issue. I'll also write another pull request that fixes the issue on 1.21 once I've written it.